### PR TITLE
fixes windows bug by using windows default browser'

### DIFF
--- a/useIt.py
+++ b/useIt.py
@@ -21,6 +21,9 @@ class UseItCommand(sublime_plugin.TextCommand):
         s = sublime.load_settings("Can I Use.sublime-settings")
         default_browser = s.get('default_browser', '')
 
+        if not default_browser and sublime.platform() == 'windows':
+            default_browser = 'windows-default'
+
         for region in self.view.sel():
             # Get the start point of the region of the selection
             point = region.begin()


### PR DESCRIPTION
Ran into a minor bug where the plugin wouldn't work because webbrowser could not detect my default browser on windows 8.1.
'' wont work, but 'windows-default' does, and is reverted when user changes their CanIUse settings file.
This should make plugin work out of the box with Windows users.

If you decide not to pull, a README change specifying that windows users must change their default browser setting to 'windows_default' after install would be nice.
